### PR TITLE
fix: disable horizontal scrolling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,6 +83,10 @@
   * {
     @apply border-border;
   }
+  html,
+  body {
+    @apply overflow-x-hidden;
+  }
   body {
     @apply bg-background text-foreground;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.7' numOctaves='10' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.05'/%3E%3C/svg%3E");

--- a/src/components/dashboard/elo-chart.tsx
+++ b/src/components/dashboard/elo-chart.tsx
@@ -32,8 +32,8 @@ export function EloChart({ data }: EloChartProps) {
       </CardHeader>
       <CardContent>
         {data.length > 0 ? (
-            <ChartContainer config={chartConfig} className="h-[250px] w-full">
-            <LineChart data={data} margin={{ top: 5, right: 10, left: -10, bottom: 0 }}>
+            <ChartContainer config={chartConfig} className="h-[250px] w-full aspect-auto">
+            <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} />
                 <XAxis 
                     dataKey="date" 


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling by hiding x-overflow
- ensure dashboard chart fits within screen to avoid horizontal scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4257af65c8325acfbaddc344df3c0