### PR TITLE
Fix profile links 404

### DIFF
--- a/src/app/(app)/profile/[id]/page.tsx
+++ b/src/app/(app)/profile/[id]/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from 'react';
+import ProfileClientView from './ClientView';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+
+export default function ProfilePageById({ params }: { params: { id: string } }) {
+  return (
+    <Suspense fallback={<div className="flex h-full w-full items-center justify-center"><LoadingSpinner className="h-8 w-8" /></div>}>
+      <ProfileClientView id={params.id} />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- Add page component for `/profile/[id]` so profile links render instead of 404

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a430d1bd588325a9d4af26bcccfafc