### PR TITLE
Fix profile links 404

### DIFF
--- a/src/app/(app)/profile/[id]/page.tsx
+++ b/src/app/(app)/profile/[id]/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from 'react';
+import ProfileClientView from './ClientView';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+
+export default function ProfilePageById({ params }: { params: { id: string } }) {
+  return (
+    <Suspense fallback={<div className="flex h-full w-full items-center justify-center"><LoadingSpinner className="h-8 w-8" /></div>}>
+      <ProfileClientView id={params.id} />
+    </Suspense>
+  );
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -40,6 +40,7 @@ import {
     getFriendshipStatus,
     deleteGame,
     getGameFromDb,
+    getUserByUsername,
     deleteOpenChallenge,
     logPracticeSession,
     deletePracticeSession,
@@ -751,18 +752,22 @@ const calculateLongestStreak = (matches: Match[], targetPlayerId: string): numbe
 };
 
 
-export async function getProfilePageDataAction(profileUserId: string, currentUserId: string | null, sport: Sport) {
-    const profileUserDoc = await getGameFromDb<User>(profileUserId, 'users');
+export async function getProfilePageDataAction(profileUserIdOrUsername: string, currentUserId: string | null, sport: Sport) {
+    let profileUserDoc = await getGameFromDb<User>(profileUserIdOrUsername, 'users');
+    if (!profileUserDoc) {
+        profileUserDoc = await getUserByUsername(profileUserIdOrUsername);
+    }
     if (!profileUserDoc) return null;
     const profileUser = profileUserDoc;
+    const profileUserId = profileUser.uid;
 
     const recentMatches = await getConfirmedMatchesForUser(profileUserId, 5);
-    
+
     if (currentUserId && currentUserId !== profileUserId) {
         const friendship = await getFriendshipStatus(currentUserId, profileUserId);
-        
+
         const headToHeadMatches = await getHeadToHeadMatches(currentUserId, profileUserId, sport);
-        
+
         const currentUserWins = headToHeadMatches.filter(m => m.winner.includes(currentUserId)).length;
         const profileUserWins = headToHeadMatches.filter(m => m.winner.includes(profileUserId)).length;
 

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -111,6 +111,13 @@ export async function searchUsers(usernameQuery: string, currentUserId: string):
     }
 }
 
+export async function getUserByUsername(username: string): Promise<User | null> {
+    const q = query(collection(db, 'users'), where('username', '==', username));
+    const snapshot = await getDocs(q);
+    if (snapshot.empty) return null;
+    return snapshot.docs[0].data() as User;
+}
+
 async function isUsernameUnique(username: string, userId: string): Promise<boolean> {
   const q = query(collection(db, 'users'), where('username', '==', username.toLowerCase()));
   const snapshot = await getDocs(q);


### PR DESCRIPTION
## Summary
- Add helper to look up users by username
- Fallback to username lookup when profile UID not found

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a430d1bd588325a9d4af26bcccfafc